### PR TITLE
Add github test workflow

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,24 @@
+name: Run tests
+on:
+  push:
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install test requirements
+        run: |
+          pip install tox
+
+      - name: Run tests
+        run: |
+          tox

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ VERSION = "0.1.0"
 
 def get_long_description():
     with io.open(
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), "README.md"),
-            encoding="utf8",
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "README.md"),
+        encoding="utf8",
     ) as fp:
         return fp.read()
 
@@ -28,7 +28,8 @@ setup(
         "warcio==1.7.4",
         "click==8.1.3",
         "more-itertools",
-        "tqdm"
+        "tqdm",
+        "requests",
     ],
     extras_require={"test": ["pytest"]},
     entry_points="""
@@ -51,5 +52,5 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-    ]
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py3
+
+[testenv]
+deps = pytest
+commands = pytest


### PR DESCRIPTION
Run tests on pushes and pull requests

We use tox [1] to drive the tests since this takes care of creating a
virtual environment, installing the package into it, and running
tests. Running in a clean virtual environment helps catch problems
like missing dependencies.

[1]: https://tox.wiki/en/latest/