### PR TITLE
Implicitly migrate on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ pip install warcdb
 ```
 
 ```shell
-
-# Create the database `archive.warcdb`.
-warcdb init archive.warcdb
-
 # Load the `archive.warcdb` file with data.
 warcdb import archive.warcdb ./tests/google.warc ./tests/frontpages.warc.gz "https://tselai.com/data/google.warc"
 
@@ -44,10 +40,9 @@ Individual `.warc` files are read and parsed and their data is inserted into an 
 
 ## Schema
 
-If there is a new major or minor version of warcdb you may need to migrate existing databases to use the new database schema (if there have been any changes). To do this you first upgrade warcdb, and then migrate the database:
+If there is a new major or minor version of warcdb you may need to migrate existing databases to use the new database schema (if there have been any changes). To do this you first upgrade warcdb, and then import into the database, which will make sure all migrations have been run. If you want to migrate the database explicitly you can:
 
 ```shell
-pip install --upgrade warcdb
 warcdb migrate archive.warcdb
 ```
 

--- a/tests/test_warcdb.py
+++ b/tests/test_warcdb.py
@@ -24,11 +24,6 @@ tests_dir = pathlib.Path(__file__).parent
 
 def test_import(warc_path):
     runner = CliRunner()
-
-    # initialize db
-    result = runner.invoke(warcdb_cli, ['init', db_file])
-    assert result.exit_code == 0
-
     args = ["import", db_file, warc_path]
     result = runner.invoke(warcdb_cli, args)
     assert result.exit_code == 0
@@ -46,7 +41,6 @@ def test_import(warc_path):
 
 def test_column_names():
     runner = CliRunner()
-    runner.invoke(warcdb_cli, ['init', db_file])
     runner.invoke(warcdb_cli, ["import", db_file, str(pathlib.Path('tests/google.warc'))])
 
     # make sure that the columns are named correctly (lowercase with underscores)

--- a/warcdb/__init__.py
+++ b/warcdb/__init__.py
@@ -225,23 +225,10 @@ warcdb_cli.help = \
     "Commands for interacting with .warcdb files\n\nBased on SQLite-Utils"
 
 
-@warcdb_cli.command('init')
-@click.argument(
-    "db_path",
-    type=click.Path(file_okay=True, dir_okay=False, exists=False, allow_dash=False),
-)
-def init (db_path):
-    """
-    Initialize a new warcdb database
-    """
-    db = WarcDB(db_path)
-    migration.apply(db.db)
-
-
 @warcdb_cli.command('import')
 @click.argument(
     "db_path",
-    type=click.Path(file_okay=True, dir_okay=False, exists=True, allow_dash=False),
+    type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
 )
 @click.argument('warc_path',
                 type=click.STRING,
@@ -255,6 +242,9 @@ def import_(db_path, warc_path, batch_size):
     Import a WARC file into the database
     """
     db = WarcDB(db_path, batch_size=batch_size)
+
+    # ensure the schema is there and up to date
+    migration.apply(db.db)
 
     # if batch_size:
     #    warnings.warn("--batch-size has been temporarily disabled")


### PR DESCRIPTION
In order not to require an extra `init` step, and for the user not to need to know when to update their database with a `migrate`, we can migrate the database every time a user does an `import`.

Implicitly migrating the database when importing will:

1. ensure that there is a complete database schema to import into
2. ensure that the schema is up to date with the latest installed version of warcdb

I'm not sure if we should create a separate ticket for detecting the case when the SQLite database is for a newer version of warcdb than is installed. Perhaps we can use the `_sqlite_migrations` table to determine this?

```
sqlite> select * from _sqlite_migrations;
migration_set  name          applied_at
-------------  ------------  --------------------------
warcdb         m001_initial  2023-10-20 10:24:35.114387
```

Closes #18 